### PR TITLE
Extension of VFPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each SID can contain multiple objects with defined options based on restrictions
 Available restrictions:
 - "destinations" - Array of strings. The object only applies to FPL with one of the given destination ICAOs. Partials are possible, ex. "ED"
 - "engine" - Either string or array of strings. The object only applies to AC with one of the given Engine Types. Options are "P" (piston), "T" (turboprop/turboshaft), "J" (jet) and "E" (electric), as defined by Euroscope
+- "navigation" - A string which contains the equipment codes which defines all allowed capabilities for the SID
 - "airways" - Array of strings. The object only applies to FPL if route contains any of the given airways
 
 Available options:

--- a/Sid.json
+++ b/Sid.json
@@ -329,43 +329,333 @@
          ],
          "ARSAP": [
             {
-                "engine": "J",
                 "suffix": "1B",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
                 "direction": "ODD"
             },
             {
-                "engine": "T",
                 "suffix": "1D",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "ODD"
+            },
+            {
+                "suffix": "1Q",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "ODD"
+            },
+            {
+                "suffix": "1Z",
+                "navigation": "MNPYCIEFGRW",
                 "direction": "ODD"
             }
          ],
          "GERGA": [
             {
+                "suffix": "1B",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
                 "direction": "ODD"
+            },
+            {
+                "suffix": "1D",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "ODD"
+            },
+            {
+                "suffix": "1Q",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "ODD"
+            },
+            {
+                "suffix": "1Z",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "ODD"
+            }
+         ],
+         "LUROS": [
+            {
+                "suffix": "1B",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1D",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Q",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Z",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
             }
          ],
          "POVEL": [
             {
+                "suffix": "1B",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1D",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1K",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1J",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Q",
+                "engine": "J",
+                "min_fl": 120,
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1R",
+                "engine": "P",
+                "min_fl": 120,
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Y",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Z",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
                 "direction": "EVEN"
             }
          ],
          "HLZ": [
             {
+                "suffix": "1B",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1D",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1K",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1J",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Q",
+                "engine": "J",
+                "min_fl": 120,
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1R",
+                "engine": "P",
+                "min_fl": 120,
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Y",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Z",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
                 "direction": "EVEN"
             }
          ],
          "MAXAN": [
             {
+                "suffix": "1B",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1D",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1K",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1J",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Q",
+                "engine": "J",
+                "min_fl": 120,
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1R",
+                "engine": "P",
+                "min_fl": 120,
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Y",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Z",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
                 "direction": "EVEN"
             }
          ],
          "ODLUN": [
             {
+                "suffix": "1B",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1D",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1K",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1J",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Q",
+                "engine": "J",
+                "min_fl": 120,
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1R",
+                "engine": "P",
+                "min_fl": 120,
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Y",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Z",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
                 "direction": "EVEN"
             }
          ],
          "SOGMA": [
             {
+                "suffix": "1B",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1D",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1K",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1J",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Q",
+                "engine": "J",
+                "min_fl": 120,
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1R",
+                "engine": "P",
+                "min_fl": 120,
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Y",
+                "engine": "T",
+                "navigation": "MNPYCIEFGRW",
+                "direction": "EVEN"
+            },
+            {
+                "suffix": "1Z",
+                "engine": "J",
+                "navigation": "MNPYCIEFGRW",
                 "direction": "EVEN"
             }
          ]

--- a/Sid.json
+++ b/Sid.json
@@ -324,50 +324,49 @@
       "sids": {
          "VCT": [
             {
-               "direction": "ANY"
+                "direction": "ANY"
             }
          ],
-         "BELID": [
+         "ARSAP": [
             {
-               "direction": "EVEN"
-            }
-         ],
-         "BKD": [
+                "engine": "J",
+                "suffix": "1B",
+                "direction": "ODD"
+            },
             {
-               "direction": "EVEN"
+                "engine": "T",
+                "suffix": "1D",
+                "direction": "ODD"
             }
          ],
          "GERGA": [
             {
-               "direction": "ODD",
-               "airways": [
-                  "RENKI L132",
-                  "Y218"
-               ]
-            },
-            {
-               "direction": "EVEN"
+                "direction": "ODD"
             }
          ],
-         "TUVAD": [
+         "POVEL": [
             {
-               "direction": "EVEN",
-               "destinations": [
-                  "EDDM"
-               ]
-            },
-            {
-               "direction": "ODD"
+                "direction": "EVEN"
             }
          ],
-         "KLF": [
+         "HLZ": [
             {
-               "direction": "ANY",
-               "destinations": [
-                  "EDDT",
-                  "EDDB",
-                  "EDDI"
-               ]
+                "direction": "EVEN"
+            }
+         ],
+         "MAXAN": [
+            {
+                "direction": "EVEN"
+            }
+         ],
+         "ODLUN": [
+            {
+                "direction": "EVEN"
+            }
+         ],
+         "SOGMA": [
+            {
+                "direction": "EVEN"
             }
          ]
       }

--- a/VFPC.vcxproj.user
+++ b/VFPC.vcxproj.user
@@ -1,4 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LocalDebuggerCommand>C:\DevTools\Euroscope\EuroScope.exe</LocalDebuggerCommand>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerWorkingDirectory>C:\DevTools\Euroscope\</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LocalDebuggerCommand>C:\DevTools\Euroscope\EuroScope.exe</LocalDebuggerCommand>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerWorkingDirectory>C:\DevTools\Euroscope\</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
 </Project>

--- a/analyzeFP.cpp
+++ b/analyzeFP.cpp
@@ -94,7 +94,7 @@ void CVFPCPlugin::getSids() {
 
 // Does the checking and magic stuff, so everything will be alright, when this is finished! Or not. Who knows?
 vector<string> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
-	vector<string> returnValid{}; // 0 = Callsign, 1 = valid/invalid SID, 2 = SID Name, 3 = Destination, 4 = Airway, 5 = Engine Type, 6 = Even/Odd, 7 = Minimum Flight Level, 8 = Maximum Flight Level, 9 = Passed
+	vector<string> returnValid{}; // 0 = Callsign, 1 = valid/invalid SID, 2 = SID Name, 3 = Destination, 4 = Airway, 5 = Engine Type, 6 = Even/Odd, 7 = Minimum Flight Level, 8 = Maximum Flight Level, 9 = Navigation restriction, 10 = Passed
 
 	returnValid.push_back(flightPlan.GetCallsign());
 	bool valid{ false };
@@ -124,7 +124,7 @@ vector<string> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
 	if (airports.find(origin) == airports.end()) {
 		returnValid.push_back("Invalid");
 		returnValid.push_back("No valid Airport found!");
-		for (int i = 0; i < 6; i++) {
+		for (int i = 0; i < 7; i++) {
 			returnValid.push_back("-");
 		}
 		returnValid.push_back("Failed");
@@ -159,7 +159,7 @@ vector<string> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
 	for (SizeType i = 0; i < conditions.Size(); i++) {
 		returnValid.clear();
 		returnValid.push_back(flightPlan.GetCallsign());
-		bool passed[6]{ false };
+		bool passed[7]{ false };
 		valid = false;
 
 		// Skip SID if the check is suffix-related
@@ -184,7 +184,6 @@ vector<string> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
 			returnValid.push_back("No Destination restriction");
 			passed[0] = true;
 		}
-
 
 		// Does Condition contain our first airway if it's limited
 		if (conditions[i]["airways"].IsArray() && conditions[i]["airways"].Size()) {
@@ -294,10 +293,25 @@ vector<string> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
 			passed[5] = true;
 		}
 
-
+		// Special navigation requirements needed
+		if (conditions[i]["navigation"].IsString()) {
+			std::string navigation_constraints(conditions[i]["navigation"].GetString());
+			if (std::string::npos == navigation_constraints.find_first_of(flightPlan.GetFlightPlanData().GetCapibilities())) {
+				returnValid.push_back("Failed navigation capability restriction. Req. capability: " + navigation_constraints);
+				passed[6] = false;
+			}
+			else {
+				returnValid.push_back("No navigation capability restriction");
+				passed[6] = true;
+			}
+		}
+		else {
+			returnValid.push_back("No navigation capability restriction");
+			passed[6] = true;
+		}
 
 		bool passedVeri{ false };
-		for (int i = 0; i < 6; i++) {
+		for (int i = 0; i < 7; i++) {
 			if (passed[i])
 			{
 				passedVeri = true;
@@ -323,7 +337,7 @@ vector<string> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
 	if (!valid) {
 		returnValid.push_back("Invalid");
 		returnValid.push_back("No valid SID found!");
-		for (int i = 0; i < 5; i++) {
+		for (int i = 0; i < 7; i++) {
 			returnValid.push_back("-");
 		}
 		returnValid.push_back("Failed");
@@ -357,9 +371,9 @@ void CVFPCPlugin::OnGetTagItem(CFlightPlan FlightPlan, CRadarTarget RadarTarget,
 			strcpy_s(sItemString, 16, "VFR");
 		}
 		else {
-			vector<string> messageBuffer{ validizeSid(FlightPlan) }; // 0 = Callsign, 1 = valid/invalid SID, 2 = SID Name, 3 = Destination, 4 = Airway, 5 = Engine Type, 6 = Even/Odd, 7 = Minimum Flight Level, 8 = Maximum Flight Level, 9 = Passed
+			vector<string> messageBuffer{ validizeSid(FlightPlan) }; // 0 = Callsign, 1 = valid/invalid SID, 2 = SID Name, 3 = Destination, 4 = Airway, 5 = Engine Type, 6 = Even/Odd, 7 = Minimum Flight Level, 8 = Maximum Flight Level, 9 = Navigation restriction, 10 = Passed
 			
-			if (messageBuffer.at(9) == "Passed") {
+			if (messageBuffer.at(10) == "Passed") {
 				*pRGB = TAG_GREEN;
 				strcpy_s(sItemString, 16, "OK!");
 			}
@@ -416,11 +430,11 @@ void CVFPCPlugin::checkFPDetail() {
 	string buffer{ messageBuffer.at(1) };
 	if (messageBuffer.at(1) == "Valid") {
 		buffer += ", found SID: ";
-		for (int i = 2; i < 8; i++) {
+		for (int i = 2; i < 10; i++) {
 			buffer += messageBuffer.at(i);
 			buffer += ", ";
 		}
-		buffer += messageBuffer.at(9);
+		buffer += messageBuffer.at(10);
 		buffer += " FlightPlan Check. Check complete.";
 	} else {
 		buffer += " ";
@@ -455,6 +469,9 @@ string CVFPCPlugin::getFails(vector<string> messageBuffer) {
 	}
 	if (messageBuffer.at(8).find_first_of("Failed") == 0) {
 		fail.push_back("MAX");
+	}
+	if (messageBuffer.at(9).find_first_of("Failed") == 0) {
+		fail.push_back("NAV");
 	}
 
 	std::size_t couldnt = disCount;

--- a/analyzeFP.cpp
+++ b/analyzeFP.cpp
@@ -105,7 +105,7 @@ vector<string> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
 	int RFL = flightPlan.GetFlightPlanData().GetFinalAltitude();
 	
 	vector<string> route = split(flightPlan.GetFlightPlanData().GetRoute(), ' ');
-	for (int i = 0; i < route.size(); i++) {
+	for (std::size_t i = 0; i < route.size(); i++) {
 		boost::to_upper(route[i]);
 	}
 
@@ -452,7 +452,7 @@ string CVFPCPlugin::getFails(vector<string> messageBuffer) {
 		fail.push_back("MAX");
 	}
 
-	int couldnt = disCount;
+	std::size_t couldnt = disCount;
 	while (couldnt >= fail.size())
 		couldnt -= fail.size();
 	return fail[couldnt];

--- a/analyzeFP.cpp
+++ b/analyzeFP.cpp
@@ -111,6 +111,7 @@ vector<string> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
 
 	string sid = flightPlan.GetFlightPlanData().GetSidName(); boost::to_upper(sid);
 	string first_wp = sid.substr(0, sid.find_first_of("0123456789")); boost::to_upper(first_wp);
+	string sid_suffix = sid.substr(sid.find_first_of("0123456789"), sid.length()); boost::to_upper(sid_suffix);
 	string first_airway;
 
 	vector<string>::iterator it = find(route.begin(), route.end(), first_wp);
@@ -161,6 +162,10 @@ vector<string> CVFPCPlugin::validizeSid(CFlightPlan flightPlan) {
 		bool passed[6]{ false };
 		valid = false;
 
+		// Skip SID if the check is suffix-related
+		if (conditions[i]["suffix"].IsString() && conditions[i]["suffix"].GetString() != sid_suffix) {
+			continue;
+		}
 
 		// Does Condition contain our destination if it's limited
 		if (conditions[i]["destinations"].IsArray() && conditions[i]["destinations"].Size()) {

--- a/analyzeFP.hpp
+++ b/analyzeFP.hpp
@@ -65,7 +65,7 @@ public:
 	string destArrayContains(const Value& a, string s) {
 		for (SizeType i = 0; i < a.Size(); i++) {
 			string test = a[i].GetString();
-			SizeType x = s.rfind(test, 0);
+			SizeType x = static_cast<rapidjson::SizeType>(s.rfind(test, 0));
 			if (s.rfind(a[i].GetString(), 0) != -1)
 				return a[i].GetString();
 		}


### PR DESCRIPTION
The configuration is extended by a suffix definition.
This definition is needed to differentiate between SIDs that have the same endpoint, but have different requirements.

The configuration is extended by a navigation definition.
This definition is needed if special routes require special equipment codes of the aircraft.

The validizeFp function checks if a suffix is defines and compares only the given SID with the defined suffix.
The parameter is optional. The navigation check is also used and uses the GetCapabilities-function of the flight-plan-data.